### PR TITLE
DOC: only run on merged PRs, and use hash rather than tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ on:
 jobs:
   milestone_pr:
     name: attach to PR
-    if github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: scientific-python/attach-next-milestone-action@a4889cfde7d2578c1bc7400480d93910d2dd34f6

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ on:
 jobs:
   milestone_pr:
     name: attach to PR
+    if github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: scientific-python/attach-next-milestone-action@v0.1.0
+      - uses: scientific-python/attach-next-milestone-action@a4889cfde7d2578c1bc7400480d93910d2dd34f6
         with:
           token: ${{ secrets.MILESTONE_LABELER_TOKEN }}
 ```


### PR DESCRIPTION
Doc mentions that it runs of merged PRs, but code example didn't have the conditional.

Also, I was switching the example to use a hash rather than a tag, as that's what we promote to do with the other actions in the org.

I was also wondering about using the standard GITHUB_TOKEN secret, is there a particular reason this action advises to use a new one? 